### PR TITLE
Connect settings page to JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # TestWebsite
-A testing of githubs website capabilities.
+Demonstration site with a simple settings page. Settings saved on the main
+page are persisted using browser `localStorage` and displayed on
+`settings.html`.

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
     <!-- Button to save -->
     <button onclick="saveSettings()">Save Settings</button>
-    <a href="settings.html">Go to Settings</a>
+    <a id="settingsLink" href="settings.html" target="_blank">Go to Settings</a>
 
     <!-- Display JSON -->
     <pre id="output"></pre>
@@ -31,6 +31,23 @@
         const speedSlider = document.getElementById('speedSlider');
         const speedValue = document.getElementById('speedValue');
         const output = document.getElementById('output');
+        const settingsLink = document.getElementById('settingsLink');
+
+        // Load settings from localStorage on page load
+        window.addEventListener('DOMContentLoaded', () => {
+            const saved = localStorage.getItem('settings');
+            if (saved) {
+                try {
+                    const data = JSON.parse(saved);
+                    enableCheckbox.checked = !!data.enable;
+                    speedSlider.value = data.speed ?? speedSlider.value;
+                    speedValue.textContent = speedSlider.value;
+                    output.textContent = JSON.stringify(data, null, 2);
+                } catch (e) {
+                    console.error('Failed to parse saved settings');
+                }
+            }
+        });
 
         // Update visible speed value
         speedSlider.oninput = () => {
@@ -42,6 +59,8 @@
                 enable: enableCheckbox.checked,
                 speed: parseInt(speedSlider.value)
             };
+
+            localStorage.setItem('settings', JSON.stringify(settings));
 
             // Show JSON output on page
             output.textContent = JSON.stringify(settings, null, 2);

--- a/settings.html
+++ b/settings.html
@@ -1,44 +1,20 @@
-<!-- File: settings.html -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Settings - TestSite</title>
+    <title>Current Settings</title>
 </head>
 <body>
-    <h1>TestSite Settings</h1>
-
-    <label>
-        <input type="checkbox" id="enableCheckbox"> Enable
-    </label>
-    <br><br>
-
-    <label for="speedSlider">Speed:</label>
-    <input type="range" id="speedSlider" min="0" max="100" value="50">
-    <span id="speedValue">50</span>
-    <br><br>
-
-    <button onclick="saveSettings()">Save Settings</button>
-
-    <pre id="output"></pre>
-
+    <h1>Current Settings</h1>
+    <pre id="output">Loading...</pre>
+    <p><a href="index.html">Back to main page</a></p>
     <script>
-        const enableCheckbox = document.getElementById('enableCheckbox');
-        const speedSlider = document.getElementById('speedSlider');
-        const speedValue = document.getElementById('speedValue');
         const output = document.getElementById('output');
-
-        speedSlider.oninput = () => {
-            speedValue.textContent = speedSlider.value;
-        };
-
-        function saveSettings() {
-            const settings = {
-                enable: enableCheckbox.checked,
-                speed: parseInt(speedSlider.value)
-            };
-
-            output.textContent = JSON.stringify(settings, null, 2);
+        const saved = localStorage.getItem('settings');
+        if (saved) {
+            output.textContent = saved;
+        } else {
+            output.textContent = 'No settings saved';
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- persist user settings from the main page with `localStorage`
- show the saved settings on `settings.html`
- document how settings work in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855bbb1ddac8320a54986dae7eb0714